### PR TITLE
BugFix: Correção no post (método criar) de Fichas

### DIFF
--- a/FilasEGuichesApi/Data/AppDbContext.cs
+++ b/FilasEGuichesApi/Data/AppDbContext.cs
@@ -50,10 +50,19 @@ namespace FilasEGuichesApi.Data
                     new TipoGuiche { Id = 1, Nome = "Atendimento", Prefixo = "A" },
                     new TipoGuiche { Id = 2, Nome = "Gerencia", Prefixo = "G" }
                 );
-
-                SaveChanges();
             }
+
+            if (!Guiches.Any())
+            {
+                Guiches.AddRange(
+                    new Guiche { Id = 1, TipoGuicheId = 1 },
+                    new Guiche { Id = 2, TipoGuicheId = 2 }
+                );
+            }
+
+            SaveChanges();
         }
+
 
         #endregion
 


### PR DESCRIPTION
Está sendo feita da forma correta, forçando cruzar os dados com a Entidade Guichê e mantendo o controle correto do valor de "Código" de Ficha, além de melhoria de performance ao trazer apenas a última ficha, ao invés de todas as fichas em memória para só depois validar o código.